### PR TITLE
Add Caps Lock indicator config item

### DIFF
--- a/Config_manager/Config_manager.h
+++ b/Config_manager/Config_manager.h
@@ -35,6 +35,7 @@ class ConfigManager
             CFG_ITEM_TYPE_LEDS_LEDMANAGER = 10,
             CFG_ITEM_TYPE_LEDS_PALETTE,
             CFG_ITEM_TYPE_LEDS_COLORMAP,
+            CFG_ITEM_TYPE_LEDS_CAPS_LOCK_INDICATOR,
 
             CFG_ITEM_TYPE_BATTERY = 20,
 


### PR DESCRIPTION
Draft support PR for the Caps Lock LED indicator configuration.

Discussion:
- Dygmalab/Bazecor#1126

Depends on:
- Dygmalab/NeuronLedLibrary#10

This PR adds:
- CFG_ITEM_TYPE_LEDS_CAPS_LOCK_INDICATOR
- updated NeuronLedLibrary submodule pointer for the new LEDManager Focus commands

This is not the full live indicator behavior yet. It only wires the shared library/config layer needed by the Neuron firmware and Bazecor UI.